### PR TITLE
Rename modules to salt-extension-copier convention

### DIFF
--- a/docs/ref/auth/index.rst
+++ b/docs/ref/auth/index.rst
@@ -9,4 +9,4 @@ ____________
 .. autosummary::
     :toctree:
 
-    ldap
+    ldap_mod

--- a/docs/ref/auth/saltext.ldap.auth.ldap.rst
+++ b/docs/ref/auth/saltext.ldap.auth.ldap.rst
@@ -1,5 +1,0 @@
-``ldap``
-========
-
-.. automodule:: saltext.ldap.auth.ldap
-    :members:

--- a/docs/ref/auth/saltext.ldap.auth.ldap_mod.rst
+++ b/docs/ref/auth/saltext.ldap.auth.ldap_mod.rst
@@ -1,0 +1,5 @@
+``ldap``
+========
+
+.. automodule:: saltext.ldap.auth.ldap_mod
+    :members:

--- a/docs/ref/modules/index.rst
+++ b/docs/ref/modules/index.rst
@@ -10,4 +10,4 @@ _________________
     :toctree:
 
     ldap3
-    ldapmod
+    ldap_mod

--- a/docs/ref/modules/saltext.ldap.modules.ldap_mod.rst
+++ b/docs/ref/modules/saltext.ldap.modules.ldap_mod.rst
@@ -1,0 +1,5 @@
+``ldap``
+========
+
+.. automodule:: saltext.ldap.modules.ldap_mod
+    :members:

--- a/docs/ref/modules/saltext.ldap.modules.ldapmod.rst
+++ b/docs/ref/modules/saltext.ldap.modules.ldapmod.rst
@@ -1,5 +1,0 @@
-``ldap``
-========
-
-.. automodule:: saltext.ldap.modules.ldapmod
-    :members:

--- a/docs/ref/pillar/index.rst
+++ b/docs/ref/pillar/index.rst
@@ -9,4 +9,4 @@ ______________
 .. autosummary::
     :toctree:
 
-    pillar_ldap
+    ldap_mod

--- a/docs/ref/pillar/saltext.ldap.pillar.ldap_mod.rst
+++ b/docs/ref/pillar/saltext.ldap.pillar.ldap_mod.rst
@@ -1,0 +1,5 @@
+``pillar_ldap``
+===============
+
+.. automodule:: saltext.ldap.pillar.ldap_mod
+    :members:

--- a/docs/ref/pillar/saltext.ldap.pillar.pillar_ldap.rst
+++ b/docs/ref/pillar/saltext.ldap.pillar.pillar_ldap.rst
@@ -1,5 +1,0 @@
-``pillar_ldap``
-===============
-
-.. automodule:: saltext.ldap.pillar.pillar_ldap
-    :members:

--- a/docs/ref/states/index.rst
+++ b/docs/ref/states/index.rst
@@ -9,4 +9,4 @@ _____________
 .. autosummary::
     :toctree:
 
-    ldap
+    ldap_mod

--- a/docs/ref/states/saltext.ldap.states.ldap.rst
+++ b/docs/ref/states/saltext.ldap.states.ldap.rst
@@ -1,5 +1,0 @@
-``ldap``
-========
-
-.. automodule:: saltext.ldap.states.ldap
-    :members:

--- a/docs/ref/states/saltext.ldap.states.ldap_mod.rst
+++ b/docs/ref/states/saltext.ldap.states.ldap_mod.rst
@@ -1,0 +1,5 @@
+``ldap``
+========
+
+.. automodule:: saltext.ldap.states.ldap_mod
+    :members:

--- a/src/saltext/ldap/auth/ldap_mod.py
+++ b/src/saltext/ldap/auth/ldap_mod.py
@@ -28,6 +28,15 @@ try:
 except ImportError:
     HAS_LDAP = False
 
+__virtualname__ = "ldap"
+
+
+def __virtual__():
+    if HAS_LDAP:
+        return __virtualname__
+    return False, "Missing dependency: python-ldap"
+
+
 # Defaults, override in master config
 __defopts__ = {
     "auth.ldap.basedn": "",

--- a/src/saltext/ldap/modules/ldap3.py
+++ b/src/saltext/ldap/modules/ldap3.py
@@ -5,7 +5,7 @@ Query and modify an LDAP database (alternative interface)
 .. versionadded:: 2016.3.0
 
 This is an alternative to the ``ldap`` interface provided by the
-:py:mod:`ldapmod <salt.modules.ldapmod>` execution module.
+:py:mod:`ldap <saltext.ldap.modules.ldap_mod>` execution module.
 
 :depends: - ``ldap`` Python module
 """

--- a/src/saltext/ldap/modules/ldap_mod.py
+++ b/src/saltext/ldap/modules/ldap_mod.py
@@ -68,7 +68,7 @@ def __virtual__():
         return __virtualname__
     return (
         False,
-        "The ldapmod execution module cannot be loaded: ldap config not present.",
+        "The ldap execution module cannot be loaded: ldap config not present.",
     )
 
 

--- a/src/saltext/ldap/pillar/ldap_mod.py
+++ b/src/saltext/ldap/pillar/ldap_mod.py
@@ -139,13 +139,15 @@ except ImportError:
 # Set up logging
 log = logging.getLogger(__name__)
 
+__virtualname__ = "pillar_ldap"
+
 
 def __virtual__():
     """
     Only return if ldap module is installed
     """
     if HAS_LDAP:
-        return "pillar_ldap"
+        return __virtualname__
     else:
         return False
 

--- a/src/saltext/ldap/states/ldap_mod.py
+++ b/src/saltext/ldap/states/ldap_mod.py
@@ -18,6 +18,12 @@ from salt.utils.stringutils import to_bytes
 
 log = logging.getLogger(__name__)
 
+__virtualname__ = "ldap"
+
+
+def __virtual__():
+    return __virtualname__
+
 
 def managed(name, entries, connect_spec=None, attrlist=None):
     """Ensure the existence (or not) of LDAP entries and their attributes
@@ -177,14 +183,14 @@ def managed(name, entries, connect_spec=None, attrlist=None):
 
     :param connect_spec:
         See the description of the ``connect_spec`` parameter of the
-        :py:func:`ldap3.connect <salt.modules.ldap3.connect>` function
-        in the :py:mod:`ldap3 <salt.modules.ldap3>` execution module.
+        :py:func:`ldap3.connect <saltext.ldap.modules.ldap3.connect>` function
+        in the :py:mod:`ldap3 <saltext.ldap.modules.ldap3>` execution module.
         If this is a dict and the ``'url'`` entry is not specified,
         the ``'url'`` entry is set to the value of the ``name``
         parameter.
 
     :param attrlist:
-        Passed directly to :py:func:`ldap3.connect <salt.modules.ldap3.search>`
+        Passed directly to :py:func:`ldap3.connect <saltext.ldap.modules.ldap3.search>`
         to filter the attributes returned by the LDAP server. By default, all
         user attributes will be requested, and this should only need to be
         modified if management of operational attributes is desired.

--- a/tests/unit/auth/test_ldap.py
+++ b/tests/unit/auth/test_ldap.py
@@ -1,16 +1,16 @@
 """
-Unit tests for salt.auth.ldap
+Unit tests for saltext.ldap.auth.ldap_mod
 """
 
 from unittest.mock import patch
 
 import pytest
 
-import saltext.ldap.auth.ldap
+import saltext.ldap.auth.ldap_mod
 
 pytestmark = [
     pytest.mark.skipif(
-        not saltext.ldap.auth.ldap.HAS_LDAP, reason="Install python-ldap for this test"
+        not saltext.ldap.auth.ldap_mod.HAS_LDAP, reason="Install python-ldap for this test"
     ),
 ]
 
@@ -33,7 +33,7 @@ class Bind:
 @pytest.fixture
 def configure_loader_modules():
     return {
-        saltext.ldap.auth.ldap: {
+        saltext.ldap.auth.ldap_mod: {
             "__opts__": {
                 "auth.ldap.binddn": ("uid={{username}},cn=users,cn=compat,dc=saltstack,dc=com"),
                 "auth.ldap.port": 389,
@@ -53,54 +53,54 @@ def test_config():
     """
     Test that the _config function works correctly
     """
-    assert saltext.ldap.auth.ldap._config("basedn") == "dc=saltstack,dc=com"
+    assert saltext.ldap.auth.ldap_mod._config("basedn") == "dc=saltstack,dc=com"
     assert (
-        saltext.ldap.auth.ldap._config("group_filter")
+        saltext.ldap.auth.ldap_mod._config("group_filter")
         == "(&(memberUid={{ username }})(objectClass=posixgroup))"
     )
-    assert saltext.ldap.auth.ldap._config("accountattributename") == "memberUid"
-    assert saltext.ldap.auth.ldap._config("groupattribute") == "memberOf"
+    assert saltext.ldap.auth.ldap_mod._config("accountattributename") == "memberUid"
+    assert saltext.ldap.auth.ldap_mod._config("groupattribute") == "memberOf"
 
 
 def test_groups_freeipa():
     """
     test groups in freeipa
     """
-    with patch.dict(saltext.ldap.auth.ldap.__opts__, {"auth.ldap.freeipa": True}):
-        with patch("saltext.ldap.auth.ldap._bind", return_value=Bind):
-            assert "saltusers" in saltext.ldap.auth.ldap.groups("saltuser", password="password")
+    with patch.dict(saltext.ldap.auth.ldap_mod.__opts__, {"auth.ldap.freeipa": True}):
+        with patch("saltext.ldap.auth.ldap_mod._bind", return_value=Bind):
+            assert "saltusers" in saltext.ldap.auth.ldap_mod.groups("saltuser", password="password")
 
 
 def test_groups():
     """
     test groups in ldap
     """
-    with patch("saltext.ldap.auth.ldap._bind", return_value=Bind):
-        assert "saltusers" in saltext.ldap.auth.ldap.groups("saltuser", password="password")
+    with patch("saltext.ldap.auth.ldap_mod._bind", return_value=Bind):
+        assert "saltusers" in saltext.ldap.auth.ldap_mod.groups("saltuser", password="password")
 
 
 def test_groups_activedirectory():
     """
     test groups in activedirectory
     """
-    with patch.dict(saltext.ldap.auth.ldap.__opts__, {"auth.ldap.activedirectory": True}):
-        with patch("saltext.ldap.auth.ldap._bind", return_value=Bind):
-            assert "saltusers" in saltext.ldap.auth.ldap.groups("saltuser", password="password")
+    with patch.dict(saltext.ldap.auth.ldap_mod.__opts__, {"auth.ldap.activedirectory": True}):
+        with patch("saltext.ldap.auth.ldap_mod._bind", return_value=Bind):
+            assert "saltusers" in saltext.ldap.auth.ldap_mod.groups("saltuser", password="password")
 
 
 def test_auth_nopass():
-    with patch.dict(saltext.ldap.auth.ldap.__opts__, {"auth.ldap.bindpw": "p@ssw0rd!"}):
-        with patch("saltext.ldap.auth.ldap._bind_for_search", return_value=Bind):
-            assert not saltext.ldap.auth.ldap.auth("foo", None)
+    with patch.dict(saltext.ldap.auth.ldap_mod.__opts__, {"auth.ldap.bindpw": "p@ssw0rd!"}):
+        with patch("saltext.ldap.auth.ldap_mod._bind_for_search", return_value=Bind):
+            assert not saltext.ldap.auth.ldap_mod.auth("foo", None)
 
 
 def test_auth_nouser():
-    with patch.dict(saltext.ldap.auth.ldap.__opts__, {"auth.ldap.bindpw": "p@ssw0rd!"}):
-        with patch("saltext.ldap.auth.ldap._bind_for_search", return_value=Bind):
-            assert not saltext.ldap.auth.ldap.auth(None, "foo")
+    with patch.dict(saltext.ldap.auth.ldap_mod.__opts__, {"auth.ldap.bindpw": "p@ssw0rd!"}):
+        with patch("saltext.ldap.auth.ldap_mod._bind_for_search", return_value=Bind):
+            assert not saltext.ldap.auth.ldap_mod.auth(None, "foo")
 
 
 def test_auth_nouserandpass():
-    with patch.dict(saltext.ldap.auth.ldap.__opts__, {"auth.ldap.bindpw": "p@ssw0rd!"}):
-        with patch("saltext.ldap.auth.ldap._bind_for_search", return_value=Bind):
-            assert not saltext.ldap.auth.ldap.auth(None, None)
+    with patch.dict(saltext.ldap.auth.ldap_mod.__opts__, {"auth.ldap.bindpw": "p@ssw0rd!"}):
+        with patch("saltext.ldap.auth.ldap_mod._bind_for_search", return_value=Bind):
+            assert not saltext.ldap.auth.ldap_mod.auth(None, None)

--- a/tests/unit/modules/test_ldap.py
+++ b/tests/unit/modules/test_ldap.py
@@ -1,7 +1,7 @@
 """
 :codeauthor: Jayesh Kariya <jayeshk@saltstack.com>
 
-Test cases for salt.modules.ldapmod
+Test cases for saltext.ldap.modules.ldap_mod
 """
 
 import time
@@ -10,12 +10,12 @@ from unittest.mock import patch
 
 import pytest
 
-from saltext.ldap.modules import ldapmod
+from saltext.ldap.modules import ldap_mod
 
 
 @pytest.fixture
 def configure_loader_modules():
-    return {ldapmod: {}}
+    return {ldap_mod: {}}
 
 
 # 'search' function tests: 1
@@ -48,10 +48,10 @@ def test_search():
             return "SALT"
 
     mock = MagicMock(return_value=True)
-    with patch.dict(ldapmod.__salt__, {"config.option": mock}):
-        with patch.object(ldapmod, "_connect", MagicMock(return_value=MockConnect())):
+    with patch.dict(ldap_mod.__salt__, {"config.option": mock}):
+        with patch.object(ldap_mod, "_connect", MagicMock(return_value=MockConnect())):
             with patch.object(time, "time", MagicMock(return_value=8e-04)):
-                assert ldapmod.search(filter="myhost") == {
+                assert ldap_mod.search(filter="myhost") == {
                     "count": 4,
                     "results": "SALT",
                     "time": {"raw": "0.0", "human": "0.0ms"},

--- a/tests/unit/modules/test_ldap.py
+++ b/tests/unit/modules/test_ldap.py
@@ -18,41 +18,141 @@ def configure_loader_modules():
     return {ldap_mod: {}}
 
 
-# 'search' function tests: 1
+class _RecordingConn:
+    """A stand-in LDAP connection that records what search_s was called with."""
+
+    def __init__(self, return_value=None):
+        self.calls = []
+        self.return_value = [] if return_value is None else return_value
+
+    def search_s(self, bdn, scope, _filter, attrs):
+        self.calls.append((bdn, scope, _filter, attrs))
+        return self.return_value
 
 
-def test_search():
-    """
-    Test if it run an arbitrary LDAP query and return the results.
-    """
+# ---------------------------------------------------------------------------
+# _config
+# ---------------------------------------------------------------------------
 
-    class MockConnect:
-        """
-        Mocking _connect method
-        """
 
-        def __init__(self):
-            self.bdn = None
-            self.scope = None
-            self._filter = None
-            self.attrs = None
+def test__config_prefers_kwargs_over_salt_config():
+    """A value passed as a kwarg should win over the master config."""
+    config_option = MagicMock(return_value="from-config")
+    with patch.dict(ldap_mod.__salt__, {"config.option": config_option}):
+        assert ldap_mod._config("server", server="from-kwargs") == "from-kwargs"
+    config_option.assert_not_called()
 
-        def search_s(self, bdn, scope, _filter, attrs):
-            """
-            Mock function for search_s
-            """
-            self.bdn = bdn
-            self.scope = scope
-            self._filter = _filter
-            self.attrs = attrs
-            return "SALT"
 
-    mock = MagicMock(return_value=True)
-    with patch.dict(ldap_mod.__salt__, {"config.option": mock}):
-        with patch.object(ldap_mod, "_connect", MagicMock(return_value=MockConnect())):
+def test__config_falls_back_to_salt_config_option():
+    """Without a kwarg, _config should pull from __salt__['config.option']."""
+    config_option = MagicMock(return_value="ldap.example.com")
+    with patch.dict(ldap_mod.__salt__, {"config.option": config_option}):
+        assert ldap_mod._config("server") == "ldap.example.com"
+    config_option.assert_called_once_with("ldap.server")
+
+
+def test__config_uses_key_alias_when_provided():
+    """The `key` parameter remaps the config option name."""
+    config_option = MagicMock(return_value="dc=acme,dc=com")
+    with patch.dict(ldap_mod.__salt__, {"config.option": config_option}):
+        ldap_mod._config("dn", key="basedn")
+    config_option.assert_called_once_with("ldap.basedn")
+
+
+def test__config_decodes_bytes_to_str():
+    """Bytes values returned by config.option must be decoded."""
+    config_option = MagicMock(return_value=b"dc=example,dc=com")
+    with patch.dict(ldap_mod.__salt__, {"config.option": config_option}):
+        result = ldap_mod._config("basedn")
+    assert result == "dc=example,dc=com"
+    assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# search
+# ---------------------------------------------------------------------------
+
+
+def test_search_returns_results_count_and_timing():
+    """search should return the LDAP result, a count, and timing metadata."""
+    conn = _RecordingConn(return_value=[("cn=a,dc=x", {"cn": ["a"]})])
+    config_option = MagicMock(return_value=True)
+    with patch.dict(ldap_mod.__salt__, {"config.option": config_option}):
+        with patch.object(ldap_mod, "_connect", MagicMock(return_value=conn)):
             with patch.object(time, "time", MagicMock(return_value=8e-04)):
-                assert ldap_mod.search(filter="myhost") == {
-                    "count": 4,
-                    "results": "SALT",
-                    "time": {"raw": "0.0", "human": "0.0ms"},
-                }
+                result = ldap_mod.search(filter="(cn=a)")
+    assert result == {
+        "count": 1,
+        "results": [("cn=a,dc=x", {"cn": ["a"]})],
+        "time": {"raw": "0.0", "human": "0.0ms"},
+    }
+
+
+def test_search_uses_kwargs_for_dn_and_scope():
+    """Explicit dn/scope kwargs override the config lookups."""
+    conn = _RecordingConn()
+    config_option = MagicMock(return_value="should-not-be-used")
+    with patch.dict(ldap_mod.__salt__, {"config.option": config_option}):
+        with patch.object(ldap_mod, "_connect", MagicMock(return_value=conn)):
+            with patch.object(time, "time", MagicMock(return_value=0.0)):
+                ldap_mod.search(filter="(cn=*)", dn="dc=explicit,dc=com", scope=1, attrs=["cn"])
+    assert conn.calls == [("dc=explicit,dc=com", 1, "(cn=*)", ["cn"])]
+
+
+def test_search_falls_back_to_config_for_dn_scope_attrs():
+    """Without kwargs, dn/scope/attrs are pulled from ldap.* config options."""
+    conn = _RecordingConn()
+    lookups = {"ldap.basedn": "dc=cfg,dc=com", "ldap.scope": "2", "ldap.attrs": ["cn"]}
+    config_option = MagicMock(side_effect=lambda name: lookups[name])
+    with patch.dict(ldap_mod.__salt__, {"config.option": config_option}):
+        with patch.object(ldap_mod, "_connect", MagicMock(return_value=conn)):
+            with patch.object(time, "time", MagicMock(return_value=0.0)):
+                ldap_mod.search(filter="(cn=*)")
+    assert conn.calls == [("dc=cfg,dc=com", 2, "(cn=*)", ["cn"])]
+
+
+def test_search_empty_attrs_string_overrides_to_all_attributes():
+    """attrs='' is the CLI escape hatch to request all attributes."""
+    conn = _RecordingConn()
+    config_option = MagicMock(return_value="dc=cfg,dc=com")
+    with patch.dict(ldap_mod.__salt__, {"config.option": config_option}):
+        with patch.object(ldap_mod, "_connect", MagicMock(return_value=conn)):
+            with patch.object(time, "time", MagicMock(return_value=0.0)):
+                ldap_mod.search(filter="(cn=*)", dn="dc=x", scope=2, attrs="")
+    # attrs=None tells python-ldap to return every attribute
+    assert conn.calls[0][3] is None
+
+
+def test_search_formats_slow_queries_in_seconds():
+    """Searches taking >= 200ms are reported in seconds, not milliseconds."""
+    conn = _RecordingConn(return_value=[])
+    times = iter([100.0, 100.5])  # start, end → 0.5s elapsed
+    config_option = MagicMock(return_value="dc=x")
+    with patch.dict(ldap_mod.__salt__, {"config.option": config_option}):
+        with patch.object(ldap_mod, "_connect", MagicMock(return_value=conn)):
+            with patch.object(time, "time", lambda: next(times)):
+                result = ldap_mod.search(filter="(cn=*)", dn="dc=x", scope=2, attrs=["cn"])
+    assert result["time"]["human"].endswith("s")
+    assert not result["time"]["human"].endswith("ms")
+    assert result["count"] == 0
+
+
+def test_search_passes_connection_kwargs_to__connect():
+    """Connection kwargs (server, port, bindpw, ...) flow through to _connect."""
+    conn = _RecordingConn()
+    connect = MagicMock(return_value=conn)
+    config_option = MagicMock(return_value="dc=x")
+    with patch.dict(ldap_mod.__salt__, {"config.option": config_option}):
+        with patch.object(ldap_mod, "_connect", connect):
+            with patch.object(time, "time", MagicMock(return_value=0.0)):
+                ldap_mod.search(
+                    filter="(cn=*)",
+                    dn="dc=x",
+                    scope=2,
+                    attrs=["cn"],
+                    server="other.example.com",
+                    bindpw="hunter2",
+                )
+    _, kwargs = connect.call_args
+    assert kwargs["server"] == "other.example.com"
+    assert kwargs["bindpw"] == "hunter2"

--- a/tests/unit/modules/test_ldap.py
+++ b/tests/unit/modules/test_ldap.py
@@ -126,11 +126,20 @@ def test_search_empty_attrs_string_overrides_to_all_attributes():
 def test_search_formats_slow_queries_in_seconds():
     """Searches taking >= 200ms are reported in seconds, not milliseconds."""
     conn = _RecordingConn(return_value=[])
-    times = iter([100.0, 100.5])  # start, end → 0.5s elapsed
+    # search() calls time.time() twice; patching time.time globally also
+    # intercepts logging/salt-factories calls, so return a steadily
+    # advancing clock instead of a fixed-length iterator.
+    clock = {"now": 100.0}
+
+    def fake_time():
+        current = clock["now"]
+        clock["now"] += 0.5
+        return current
+
     config_option = MagicMock(return_value="dc=x")
     with patch.dict(ldap_mod.__salt__, {"config.option": config_option}):
         with patch.object(ldap_mod, "_connect", MagicMock(return_value=conn)):
-            with patch.object(time, "time", lambda: next(times)):
+            with patch.object(time, "time", fake_time):
                 result = ldap_mod.search(filter="(cn=*)", dn="dc=x", scope=2, attrs=["cn"])
     assert result["time"]["human"].endswith("s")
     assert not result["time"]["human"].endswith("ms")

--- a/tests/unit/pillar/test_ldap.py
+++ b/tests/unit/pillar/test_ldap.py
@@ -1,19 +1,19 @@
 import salt.utils.stringutils
 
-from saltext.ldap.pillar import pillar_ldap
+from saltext.ldap.pillar import ldap_mod
 
 
 def test__config_returns_str():
     conf = {"foo": "bar"}
-    assert pillar_ldap._config("foo", conf) == salt.utils.stringutils.to_str("bar")
+    assert ldap_mod._config("foo", conf) == salt.utils.stringutils.to_str("bar")
 
 
 def test__conf_defaults_to_none():
     conf = {"foo": "bar"}
-    assert pillar_ldap._config("bang", conf) is None
+    assert ldap_mod._config("bang", conf) is None
 
 
 def test__conf_returns_str_from_unicode_default():
     conf = {"foo": "bar"}
     default = salt.utils.stringutils.to_unicode("bam")
-    assert pillar_ldap._config("bang", conf, default) == salt.utils.stringutils.to_str("bam")
+    assert ldap_mod._config("bang", conf, default) == salt.utils.stringutils.to_str("bam")

--- a/tests/unit/pillar/test_ldap.py
+++ b/tests/unit/pillar/test_ldap.py
@@ -1,6 +1,21 @@
+from unittest.mock import MagicMock
+
+import jinja2
+import pytest
 import salt.utils.stringutils
+from salt.exceptions import SaltInvocationError
 
 from saltext.ldap.pillar import ldap_mod
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {ldap_mod: {"__grains__": {"id": "minion-1"}, "__salt__": {}}}
+
+
+# ---------------------------------------------------------------------------
+# _config
+# ---------------------------------------------------------------------------
 
 
 def test__config_returns_str():
@@ -17,3 +32,268 @@ def test__conf_returns_str_from_unicode_default():
     conf = {"foo": "bar"}
     default = salt.utils.stringutils.to_unicode("bam")
     assert ldap_mod._config("bang", conf, default) == salt.utils.stringutils.to_str("bam")
+
+
+def test__config_decodes_bytes_values():
+    """Values stored as bytes in conf must come back as str."""
+    conf = {"server": b"ldap.example.com"}
+    result = ldap_mod._config("server", conf)
+    assert result == "ldap.example.com"
+    assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# _render_template
+# ---------------------------------------------------------------------------
+
+
+def test__render_template_substitutes_grains(tmp_path):
+    """Template should have access to __grains__ at render time."""
+    template = tmp_path / "pillar.yaml.j2"
+    template.write_text("minion_id: {{ id }}\n")
+    rendered = ldap_mod._render_template(str(template))
+    # jinja2 strips the trailing newline from templates by default
+    assert rendered == "minion_id: minion-1"
+
+
+def test__render_template_raises_when_missing(tmp_path):
+    """A missing template file should surface jinja2's TemplateNotFound."""
+    with pytest.raises(jinja2.exceptions.TemplateNotFound):
+        ldap_mod._render_template(str(tmp_path / "does-not-exist.yaml"))
+
+
+# ---------------------------------------------------------------------------
+# _result_to_dict (mode: map)
+# ---------------------------------------------------------------------------
+
+
+def test__result_to_dict_map_mode_collects_attrs_and_lists():
+    conf = {
+        "mode": "map",
+        "attrs": ["cn", "displayName", "dn"],
+        "lists": ["memberOf"],
+    }
+    result = [
+        (
+            "cn=johndoe,ou=users,dc=example,dc=com",
+            {
+                "cn": ["johndoe"],
+                "displayName": ["John Doe"],
+                "memberOf": ["cn=admins", "cn=ops"],
+                "ignored": ["never-returned"],
+            },
+        ),
+    ]
+    data = ldap_mod._result_to_dict({}, result, conf, "users")
+    assert data == {
+        "users": [
+            {
+                "dn": "cn=johndoe,ou=users,dc=example,dc=com",
+                "cn": "johndoe",
+                "displayName": "John Doe",
+                "memberOf": ["cn=admins", "cn=ops"],
+            },
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# _result_to_dict (mode: dict)
+# ---------------------------------------------------------------------------
+
+
+def test__result_to_dict_dict_mode_keyed_by_dn():
+    """With the default dict_key_attr ('dn'), records are keyed by their DN."""
+    conf = {"mode": "dict", "attrs": ["cn", "dn"], "lists": ["memberOf"]}
+    result = [
+        (
+            "cn=alice,dc=example,dc=com",
+            {"cn": ["alice"], "memberOf": ["cn=admins"]},
+        ),
+        (
+            "cn=bob,dc=example,dc=com",
+            {"cn": ["bob"], "memberOf": ["cn=users"]},
+        ),
+    ]
+    data = ldap_mod._result_to_dict({}, result, conf, "people")
+    assert data == {
+        "people": {
+            "cn=alice,dc=example,dc=com": [
+                {"dn": "cn=alice,dc=example,dc=com", "cn": "alice", "memberOf": ["cn=admins"]},
+            ],
+            "cn=bob,dc=example,dc=com": [
+                {"dn": "cn=bob,dc=example,dc=com", "cn": "bob", "memberOf": ["cn=users"]},
+            ],
+        },
+    }
+
+
+def test__result_to_dict_dict_mode_groups_by_custom_key():
+    """An explicit dict_key_attr groups entries sharing that attribute value."""
+    conf = {
+        "mode": "dict",
+        "dict_key_attr": "department",
+        "attrs": ["cn", "department"],
+    }
+    result = [
+        ("cn=alice,dc=x", {"cn": ["alice"], "department": ["eng"]}),
+        ("cn=bob,dc=x", {"cn": ["bob"], "department": ["eng"]}),
+        ("cn=carol,dc=x", {"cn": ["carol"], "department": ["sales"]}),
+    ]
+    data = ldap_mod._result_to_dict({}, result, conf, "by_dept")
+    assert set(data["by_dept"].keys()) == {"eng", "sales"}
+    assert len(data["by_dept"]["eng"]) == 2
+    assert len(data["by_dept"]["sales"]) == 1
+    assert {entry["cn"] for entry in data["by_dept"]["eng"]} == {"alice", "bob"}
+
+
+# ---------------------------------------------------------------------------
+# _do_search
+# ---------------------------------------------------------------------------
+
+
+def test__do_search_requires_filter():
+    """Missing filter is a configuration mistake and must raise."""
+    with pytest.raises(SaltInvocationError, match="missing filter"):
+        ldap_mod._do_search({"server": "ldap.example.com"})
+
+
+def test__do_search_invokes_ldap_search_with_built_args():
+    """_do_search should forward filter/dn/scope/attrs and connargs to ldap.search."""
+    search = MagicMock(return_value={"results": [("cn=a,dc=x", {"cn": ["a"]})]})
+    conf = {
+        "server": "ldap.example.com",
+        "port": 636,
+        "tls": True,
+        "binddn": "cn=svc,dc=x",
+        "bindpw": "secret",
+        "filter": "(objectClass=user)",
+        "dn": "dc=example,dc=com",
+        "scope": 2,
+        "attrs": ["cn"],
+        "lists": ["memberOf"],
+    }
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setitem(ldap_mod.__salt__, "ldap.search", search)
+        result = ldap_mod._do_search(conf)
+    assert result == [("cn=a,dc=x", {"cn": ["a"]})]
+    search.assert_called_once()
+    args, kwargs = search.call_args
+    # positional: filter, dn, scope, attrs
+    assert args[0] == "(objectClass=user)"
+    assert args[1] == "dc=example,dc=com"
+    assert args[2] == 2
+    assert sorted(args[3]) == sorted(["cn", "memberOf", "dn"])
+    # binddn+bindpw should force anonymous to False even if the conf didn't say so
+    assert kwargs["anonymous"] is False
+    assert kwargs["binddn"] == "cn=svc,dc=x"
+    assert kwargs["server"] == "ldap.example.com"
+
+
+def test__do_search_returns_empty_on_ldap_error(caplog):
+    """ldap.search raising should be swallowed with a critical log and return {}."""
+    search = MagicMock(side_effect=RuntimeError("boom"))
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setitem(ldap_mod.__salt__, "ldap.search", search)
+        assert ldap_mod._do_search({"filter": "(cn=*)"}) == {}
+
+
+# ---------------------------------------------------------------------------
+# ext_pillar
+# ---------------------------------------------------------------------------
+
+
+def test_ext_pillar_returns_empty_when_config_missing(tmp_path, caplog):
+    """A nonexistent config file is logged at debug and returns {} (no crash)."""
+    missing = tmp_path / "nope.yaml"
+    assert ldap_mod.ext_pillar("minion-1", {}, str(missing)) == {}
+
+
+def test_ext_pillar_returns_empty_for_non_dict_yaml(tmp_path):
+    cfg = tmp_path / "bad.yaml"
+    cfg.write_text("- just\n- a\n- list\n")
+    assert ldap_mod.ext_pillar("minion-1", {}, str(cfg)) == {}
+
+
+def test_ext_pillar_returns_empty_when_search_order_missing(tmp_path):
+    cfg = tmp_path / "noorder.yaml"
+    cfg.write_text("source1:\n  filter: '(cn=*)'\n")
+    assert ldap_mod.ext_pillar("minion-1", {}, str(cfg)) == {}
+
+
+def test_ext_pillar_returns_empty_on_yaml_parse_error(tmp_path):
+    cfg = tmp_path / "broken.yaml"
+    # Unbalanced YAML mapping triggers a YAMLError, not just a falsy value
+    cfg.write_text("source1:\n  filter: '(cn=*)\n  bad: : :\n")
+    assert ldap_mod.ext_pillar("minion-1", {}, str(cfg)) == {}
+
+
+def test_ext_pillar_aggregates_results_in_search_order(tmp_path):
+    """Each source's results are funneled through _result_to_dict and merged."""
+    cfg = tmp_path / "good.yaml"
+    cfg.write_text(
+        "users:\n"
+        "  filter: '(objectClass=user)'\n"
+        "  mode: map\n"
+        "  attrs: ['cn']\n"
+        "search_order:\n"
+        "  - users\n"
+    )
+    search = MagicMock(
+        return_value={
+            "results": [("cn=alice,dc=x", {"cn": ["alice"]})],
+        },
+    )
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setitem(ldap_mod.__salt__, "ldap.search", search)
+        data = ldap_mod.ext_pillar("minion-1", {}, str(cfg))
+    assert data == {"users": [{"cn": "alice"}]}
+    search.assert_called_once()
+
+
+def test_ext_pillar_renders_jinja_with_grains(tmp_path):
+    """The config file is jinja-rendered with __grains__ before YAML parsing."""
+    cfg = tmp_path / "templated.yaml"
+    cfg.write_text(
+        "u_{{ id }}:\n"
+        "  filter: '(uid={{ id }})'\n"
+        "  mode: map\n"
+        "  attrs: ['cn']\n"
+        "search_order:\n"
+        "  - u_{{ id }}\n"
+    )
+    search = MagicMock(return_value={"results": [("cn=minion-1,dc=x", {"cn": ["minion-1"]})]})
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setitem(ldap_mod.__salt__, "ldap.search", search)
+        data = ldap_mod.ext_pillar("minion-1", {}, str(cfg))
+    assert data == {"u_minion-1": [{"cn": "minion-1"}]}
+    # Filter passed to ldap.search should also have been rendered
+    assert search.call_args.args[0] == "(uid=minion-1)"
+
+
+def test_ext_pillar_skips_sources_with_no_results(tmp_path):
+    """A source returning {} should not contribute keys to the final data."""
+    cfg = tmp_path / "two.yaml"
+    cfg.write_text(
+        "empty:\n"
+        "  filter: '(cn=missing)'\n"
+        "  mode: map\n"
+        "  attrs: ['cn']\n"
+        "good:\n"
+        "  filter: '(cn=alice)'\n"
+        "  mode: map\n"
+        "  attrs: ['cn']\n"
+        "search_order:\n"
+        "  - empty\n"
+        "  - good\n"
+    )
+    side_effect = [
+        {"results": []},  # _do_search → [] which is falsy → skipped
+        {"results": [("cn=alice,dc=x", {"cn": ["alice"]})]},
+    ]
+    search = MagicMock(side_effect=side_effect)
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setitem(ldap_mod.__salt__, "ldap.search", search)
+        data = ldap_mod.ext_pillar("minion-1", {}, str(cfg))
+    assert data == {"good": [{"cn": "alice"}]}
+    assert search.call_count == 2

--- a/tests/unit/states/test_ldap.py
+++ b/tests/unit/states/test_ldap.py
@@ -16,7 +16,7 @@ import pytest
 from salt.utils.oset import OrderedSet
 from salt.utils.stringutils import to_bytes
 
-import saltext.ldap.states.ldap
+import saltext.ldap.states.ldap_mod
 
 log = logging.getLogger(__name__)
 
@@ -199,7 +199,7 @@ def configure_loader_modules(db):
         "ldap3.change": db.dummy_change,
         "ldap3.modify": db.dummy_modify,
     }
-    return {saltext.ldap.states.ldap: {"__opts__": {"test": False}, "__salt__": salt_dunder}}
+    return {saltext.ldap.states.ldap_mod: {"__opts__": {"test": False}, "__salt__": salt_dunder}}
 
 
 def _test_helper(init_db, expected_ret, replace, delete_others=False, attrlist=None):
@@ -269,7 +269,7 @@ def _test_helper(init_db, expected_ret, replace, delete_others=False, attrlist=N
         {dn: [{"replace": attrs}, {"delete_others": delete_others}]}
         for dn, attrs in replace.items()
     ]
-    actual = saltext.ldap.states.ldap.managed(name, entries, attrlist=attrlist)
+    actual = saltext.ldap.states.ldap_mod.managed(name, entries, attrlist=attrlist)
     assert expected_ret == actual
     assert expected_db == init_db.db
 
@@ -356,7 +356,7 @@ def _test_helper_add(db, expected_ret, add_items, delete_others=False, attrlist=
     entries = [
         {dn: [{"add": attrs}, {"delete_others": delete_others}]} for dn, attrs in add_items.items()
     ]
-    actual = saltext.ldap.states.ldap.managed(name, entries, attrlist=attrlist)
+    actual = saltext.ldap.states.ldap_mod.managed(name, entries, attrlist=attrlist)
     assert expected_ret == actual
     assert expected_db == db.db
 
@@ -373,7 +373,7 @@ def test_managed_empty(db):
         "result": True,
         "comment": "LDAP entries already set",
     }
-    actual = saltext.ldap.states.ldap.managed(name, {})
+    actual = saltext.ldap.states.ldap_mod.managed(name, {})
     assert expected == actual
 
 


### PR DESCRIPTION
Rename source/test/doc files to the <package>_mod.py / test_<package>.py naming the copier template expects, matching the `_exclude` rules that protect project-owned code on `copier update`. The Salt loader runtime names are preserved via `__virtualname__` so existing user configs, SLS files, and `__salt__` calls continue to work.

- src/saltext/ldap/auth/ldap.py            -> auth/ldap_mod.py
- src/saltext/ldap/states/ldap.py          -> states/ldap_mod.py
- src/saltext/ldap/pillar/pillar_ldap.py   -> pillar/ldap_mod.py
- src/saltext/ldap/modules/ldapmod.py      -> modules/ldap_mod.py
- tests/unit/modules/test_ldapmod.py       -> test_ldap.py
- tests/unit/pillar/test_pillar_ldap.py    -> test_ldap.py
- docs/ref/*/saltext.ldap.*.rst renamed to match

`modules/ldap3.py` is left in place as a second execution module that falls outside the copier one-module-per-loader template. Cross-module docstring references to `salt.modules.*` were updated to point at the new `saltext.ldap.*` paths.
